### PR TITLE
回答页的问题标题显示得更完整

### DIFF
--- a/Hydrogen/app/src/main/assets_bin/layout/answer.aly
+++ b/Hydrogen/app/src/main/assets_bin/layout/answer.aly
@@ -49,9 +49,9 @@
         {
           TextView;
           textColor=primaryc;
-          textSize="18sp";
+          textSize="14sp";
           id="_title";
-          SingleLine=true;
+          maxLines=2;
           ellipsize='end',
           Selected=true,
           gravity="center|left";


### PR DESCRIPTION
<img width="1873" height="1024" alt="image" src="https://github.com/user-attachments/assets/053a9c48-6d33-4917-89fc-aeeffe7cbd22" />
