### PR TITLE
修复回答页面从顶部下划容易进入左右划动的问题

### DIFF
--- a/Hydrogen/app/src/main/java/com/hydrogen/AppBarLayoutBehavior.java
+++ b/Hydrogen/app/src/main/java/com/hydrogen/AppBarLayoutBehavior.java
@@ -136,9 +136,6 @@ public class AppBarLayoutBehavior extends AppBarLayout.Behavior {
         }
         if (!shouldBlockNestedScroll) {
             super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type);
-        } else if (TYPE_FLING == type) {
-            if (null == consumed) consumed = new int[2];
-            consumed[1] = dy;
         }
     }
 
@@ -161,5 +158,6 @@ public class AppBarLayoutBehavior extends AppBarLayout.Behavior {
         isFlinging = false;
         shouldBlockNestedScroll = false;
     }
+
 
 }


### PR DESCRIPTION
## 修复原理

删掉在滑动中消费dy的代码，让子控件能继续保持垂直划动状态，避免对水平划动过度敏感。

*另：能否移除程序中的“找到重复内容”提示，略有些烦人。*