### PR TITLE
Improve home split-view behavior, auto two-column layout, and fragment replace with caching

### DIFF
--- a/Hydrogen/app/src/main/assets_bin/home.lua
+++ b/Hydrogen/app/src/main/assets_bin/home.lua
@@ -39,9 +39,16 @@ if activity.getSharedData("平行世界")~="false" then
     local height = rootView.height
     inSekai = width > dp2px(600, true)
     if f1 then
+      local leftWidth = inSekai and math.floor(width * 0.5) or width
       local lp = f1.LayoutParams
-      lp.width = inSekai and width * 0.5 or width
+      lp.width = leftWidth
       f1.setLayoutParams(lp)
+    end
+    if f2 then
+      local lp = f2.LayoutParams
+      lp.width = inSekai and math.max(0, width - math.floor(width * 0.5)) or 0
+      f2.setLayoutParams(lp)
+      f2.setVisibility(inSekai and View.VISIBLE or View.GONE)
     end
     return height, width
   end
@@ -479,6 +486,30 @@ page_home.addOnPageChangeListener(ViewPager.OnPageChangeListener {
 
 page_home.setAdapter(pagadp)
 page_home.setCurrentItem(startindex,false)
+
+local function updateHomeRecommendColumns()
+  if not home_recy then return end
+  local layoutManager = home_recy.getLayoutManager()
+  if not layoutManager or not luajava.instanceof(layoutManager, GridLayoutManager) then return end
+
+  local width = home_recy.getWidth()
+  if width <= 0 then return end
+
+  local targetSpanCount = math.max(1, math.min(2, math.floor(px2dp(width, true) / 280)))
+  if layoutManager.getSpanCount() ~= targetSpanCount then
+    layoutManager.setSpanCount(targetSpanCount)
+    home_recy.requestLayout()
+  end
+end
+
+home_recy.addOnLayoutChangeListener(View.OnLayoutChangeListener {
+  onLayoutChange=function(v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom)
+    if right - left ~= oldRight - oldLeft then
+      updateHomeRecommendColumns()
+    end
+  end
+})
+home_recy.post(updateHomeRecommendColumns)
 
 -- 如果 startindex 为 0，ViewPager 不会触发 onPageSelected，需要手动触发逻辑函数
 if startindex == 0 then

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -153,14 +153,54 @@ function 设置视图(t)
     activity.setContentView(loadlayout(t))
   end
 end
+local function getCurrentFragmentContainer()
+  if thisFragment and thisFragment.ff then
+    if thisFragment.ff == f1 then return f1 end
+    if thisFragment.ff == f2 then return f2 end
+  end
+end
+
+local function getLeastRecentContainer()
+  if tonumber(f1.getTag(R.id.tag_last_time)) > tonumber(f2.getTag(R.id.tag_last_time)) then
+    return f2
+  end
+  return f1
+end
+
+local function selectTargetContainer(fragmentName)
+  if not inSekai then return f1 end
+  if fragmentName == "home" then return f1 end
+  if fragmentName == "comment" then return f2 end
+
+  local currentContainer = getCurrentFragmentContainer()
+  if currentContainer == f2 then
+    return f2
+  end
+
+  if tostring(f1.tag) == "home" then
+    return f2
+  end
+
+  if tostring(f2.tag) == "comment" then
+    return f1
+  end
+
+  if f2.tag == fragmentName then
+    return f2
+  end
+
+  return getLeastRecentContainer()
+end
+
 function newActivity(f,b,c)
   if f1 == nil
     return activity.newActivity(f,b)
   end
   b=b or {}
-  local ff=f1
+  local ff=selectTargetContainer(f)
   local nt=tonumber(os.time())
   local t = activity.getSupportFragmentManager().beginTransaction()
+  t.setReorderingAllowed(true)
   --[[t.setCustomAnimations(
   android.R.anim.slide_in_left,
   android.R.anim.slide_out_right,
@@ -169,15 +209,6 @@ function newActivity(f,b,c)
   --t.remove(activity.getSupportFragmentManager().findFragmentByTag("answer"))
   --t.add(thisF.getId(),MyLuaFileFragment(srcLuaDir..f..".lua",b,{fn=fn,fg=fg,inSekai=inSekai,onBackCancelled=onBackCancelled,onBackStarted=onBackStarted,onBackInvoked=onBackInvoked,onBackProgressed=onBackProgressed}))
   --t.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-  if tonumber(f1.getTag(R.id.tag_last_time))>tonumber(f2.getTag(R.id.tag_last_time))
-    ff=f2
-   else
-    ff=f1
-  end
-  if f2.tag==f
-    ff=f2
-  end
-  if !inSekai then ff = f1 end
   ff.tag=f
   ff.setTag(R.id.tag_last_time,nt)
   if nTView then
@@ -220,13 +251,13 @@ function newActivity(f,b,c)
     ViewCompat.setTransitionName(nTView,"t")
     t.addSharedElement(nTView,"t")
     fragment.setSharedElementEnterTransition(forward).setSharedElementReturnTransition(backward).setEnterTransition(forward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
-    t.add(ff.id,fragment)
+    t.replace(ff.id,fragment)
    else
     backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);
     forward = MaterialSharedAxis(MaterialSharedAxis.Z, true);
     local fragment = MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,})
     fragment.postponeEnterTransition()
-    t.add(ff.id,fragment.setEnterTransition(forward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward))
+    t.replace(ff.id,fragment.setEnterTransition(forward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward))
 
   end
   t.addToBackStack(nil)

--- a/Hydrogen/app/src/main/java/com/hydrogen/MyFragmentViewmodel.java
+++ b/Hydrogen/app/src/main/java/com/hydrogen/MyFragmentViewmodel.java
@@ -1,4 +1,5 @@
 package com.hydrogen;
+import android.view.View;
 import androidx.lifecycle.ViewModel;
 import java.util.HashMap;
 
@@ -6,6 +7,8 @@ public class MyFragmentViewmodel extends ViewModel {
     String mLuaFilePath;
     HashMap mGlobal;
     Object[] mArgs;
+    View cachedContentView;
+    boolean luaFileLoaded;
     
     public MyFragmentViewmodel() {
         

--- a/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
+++ b/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
@@ -6,13 +6,13 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
+import com.google.android.material.card.MaterialCardView;
 import com.androlua.*;
 import com.luajava.*;
 
@@ -25,7 +25,7 @@ import java.util.Map;
 public class MyLuaFileFragment extends Fragment implements LuaGcable {
 
     public LuaState L;
-    public FrameLayout mContainer;
+    public MaterialCardView mContainer;
     public LuaTable mlayoutTable;
     private int mContainerId;
     private LuaActivity mLuaActivity;
@@ -48,7 +48,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
 
     }
 
-    public FrameLayout getContainer() {
+    public MaterialCardView getContainer() {
         return mContainer;
     }
 
@@ -113,7 +113,12 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         app = (LuaApplication) mLuaActivity.getApplication();
         if (mLuaFilePath.charAt(0) != '/') mLuaFilePath = mLuaActivity.getLuaDir() + "/" + mLuaFilePath;
         runFunc("onAttach", context);
-        mContainer = new FrameLayout(mLuaActivity);
+        mContainer = new MaterialCardView(mLuaActivity);
+        mContainer.setRadius(0f);
+        mContainer.setCardElevation(0f);
+        mContainer.setUseCompatPadding(false);
+        mContainer.setPreventCornerOverlap(false);
+        mContainer.setTransitionGroup(true);
         mContainer.setLayoutParams(
                 new ViewGroup.LayoutParams(
                         ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));

--- a/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
+++ b/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
@@ -56,6 +56,20 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         return mContainerId;
     }
 
+    private void scheduleStartPostponedEnterTransition() {
+        if (mContainer == null) {
+            return;
+        }
+        mContainer.post(new Runnable() {
+            @Override
+            public void run() {
+                if (isAdded()) {
+                    startPostponedEnterTransition();
+                }
+            }
+        });
+    }
+
     public void setContainerView(View v) {
         if (v.getParent() instanceof ViewGroup) {
             ((ViewGroup) v.getParent()).removeView(v);
@@ -130,6 +144,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
 
         if (mVM.cachedContentView != null && mContainer.getChildCount() == 0) {
             setContainerView(mVM.cachedContentView);
+            scheduleStartPostponedEnterTransition();
         }
 
         return mContainer;
@@ -141,6 +156,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         // 当 Fragment 的视图已经创建时调用
         runFunc("onViewCreated", view, savedInstanceState);
         if (mVM.luaFileLoaded && mContainer.getChildCount() > 0) {
+            scheduleStartPostponedEnterTransition();
             return;
         }
         try {

--- a/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
+++ b/Hydrogen/app/src/main/java/com/hydrogen/MyLuaFileFragment.java
@@ -12,7 +12,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 import com.androlua.*;
 import com.luajava.*;
@@ -34,7 +33,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
     private boolean mGc;
     private LuaApplication app;
     private final Object[] mArgs;
-    private ViewModel mVM;
+    private MyFragmentViewmodel mVM;
     private HashMap<String, Object> mGlobal;
 
     public MyLuaFileFragment(String luaFilePath) {
@@ -46,7 +45,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         mGlobal = global;
         mArgs = (args != null) ? args : new Object[0];
         mContainerId = R.id.fragment_container_view_tag;
-        
+
     }
 
     public FrameLayout getContainer() {
@@ -58,7 +57,13 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
     }
 
     public void setContainerView(View v) {
+        if (v.getParent() instanceof ViewGroup) {
+            ((ViewGroup) v.getParent()).removeView(v);
+        }
+        mContainer.removeAllViews();
         mContainer.addView(v);
+        mVM.cachedContentView = v;
+        mVM.luaFileLoaded = true;
     }
 
     @Override
@@ -100,7 +105,7 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
                         ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         mContainer.setId(mContainerId);
         mVM = new ViewModelProvider(this).get(MyFragmentViewmodel.class);
-        
+
     }
 
     @Override
@@ -123,6 +128,10 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         super.onCreateView(inflater, container, savedInstanceState);
         Object result = runFunc("onCreateView", inflater, container, savedInstanceState);
 
+        if (mVM.cachedContentView != null && mContainer.getChildCount() == 0) {
+            setContainerView(mVM.cachedContentView);
+        }
+
         return mContainer;
     }
 
@@ -131,6 +140,9 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         super.onViewCreated(view, savedInstanceState);
         // 当 Fragment 的视图已经创建时调用
         runFunc("onViewCreated", view, savedInstanceState);
+        if (mVM.luaFileLoaded && mContainer.getChildCount() > 0) {
+            return;
+        }
         try {
             doFile(mLuaFilePath, mArgs);
         } catch (LuaException e) {
@@ -169,6 +181,11 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
 
     @Override
     public void onDestroyView() {
+        if (mContainer != null && mContainer.getChildCount() > 0) {
+            View cachedView = mContainer.getChildAt(0);
+            mContainer.removeView(cachedView);
+            mVM.cachedContentView = cachedView;
+        }
         super.onDestroyView();
         // 当与 Fragment 相关的视图被移除时调用
         runFunc("onDestroyView");
@@ -179,6 +196,10 @@ public class MyLuaFileFragment extends Fragment implements LuaGcable {
         super.onDestroy();
         // 当 Fragment 被销毁时调用
         runFunc("onDestroy");
+        if (mVM != null) {
+            mVM.cachedContentView = null;
+            mVM.luaFileLoaded = false;
+        }
         gc();
     }
 


### PR DESCRIPTION
### Motivation
- Automatically adapt the home feed layout to larger widths so items become two columns when appropriate. 
- Make split (two-pane) usage more ergonomic by keeping the home pane resident and routing comment/detail pages to the secondary pane. 
- Replace fragment `add` transactions with `replace` while preserving UI state to avoid reloading Lua views on navigation.

### Description
- Add `updateHomeRecommendColumns` and an `OnLayoutChangeListener` in `layout/home.lua` to compute and set the `GridLayoutManager` span count from the actual laid-out width and post an initial update. 
- Resize and toggle visibility of left/right fragment containers in `home.lua` `updateSekai` so `f1` (home) and `f2` (secondary) get explicit widths in split mode. 
- Implement `selectTargetContainer` and helper functions in `mods/muk.lua`, enable `t.setReorderingAllowed(true)`, and change fragment transactions from `t.add(...)` to `t.replace(...)` so new fragments are placed into the chosen container. 
- Add a simple container-view cache using `MyFragmentViewmodel` and update `MyLuaFileFragment` to store/restore the Lua fragment content view across view destruction/creation by setting `mVM.cachedContentView` and `mVM.luaFileLoaded`, and avoid re-running Lua file when cached view is reused. 

### Testing
- Ran `git diff --check` to ensure no trailing-whitespace issues (passed). 
- Attempted `./gradlew :app:compileDebugJavaWithJavac` but the build failed in this environment with `Unsupported class file major version 69`, which is a tooling/JDK mismatch and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd46c3cbc8832eb42a028a1a6fdde6)