### PR TITLE
Refactor fragment container creation with MyLuaFileManager

### DIFF
--- a/Hydrogen/app/src/main/assets_bin/home.lua
+++ b/Hydrogen/app/src/main/assets_bin/home.lua
@@ -19,6 +19,7 @@ import "androidx.core.view.WindowInsetsCompat"
 
 --导入 MyViewPager
 MyViewPager = require "views/MyViewPager"
+MyLuaFileManager = require "mods.MyLuaFileManager"
 
 taskUI(function()
   local cookie = 获取Cookie("https://www.zhihu.com/")
@@ -31,6 +32,8 @@ activity.setContentView(loadlayout("layout/fragment"))
 --activity.window.setNavigationBarContrastEnforced(false)
 --edgeToedge(mainfLay,true)
 Protection=luajava.bindClass("androidx.core.view.insets.Protection")
+myLuaFileManager = MyLuaFileManager.new(fg)
+f1, f2 = myLuaFileManager:getContainerPair()
 inSekai=false
 if activity.getSharedData("平行世界")~="false" then
   local rootView = activity.getDecorView()
@@ -38,11 +41,7 @@ if activity.getSharedData("平行世界")~="false" then
     local width = rootView.width
     local height = rootView.height
     inSekai = width > dp2px(600, true)
-    if f1 then
-      local lp = f1.LayoutParams
-      lp.width = inSekai and width * 0.5 or width
-      f1.setLayoutParams(lp)
-    end
+    myLuaFileManager:setParallelMode(inSekai, width)
     return height, width
   end
   
@@ -54,19 +53,16 @@ if activity.getSharedData("平行世界")~="false" then
       end
     end
   }))
+else
+  myLuaFileManager:setParallelMode(false, activity.getDecorView().width)
 end
 
-f1.setId(View.generateViewId())
-f2.setId(View.generateViewId())
 fragmentManager = activity.getSupportFragmentManager()
 fragmentManager.beginTransaction()
 .add(f1.id,LuaFragment(loadlayout("layout/home")))
 .commit()
 
-f1.setTag("home")
-f1.setTag(R.id.tag_last_time,tonumber(os.time()))
-f2.setTag("empty")
-f2.setTag(R.id.tag_last_time,tonumber(os.time())-114514)
+myLuaFileManager:initDefaultTags()
 
 
 nav.setNavigationItemSelectedListener(NavigationView.OnNavigationItemSelectedListener{

--- a/Hydrogen/app/src/main/assets_bin/layout/fragment.aly
+++ b/Hydrogen/app/src/main/assets_bin/layout/fragment.aly
@@ -5,9 +5,8 @@
   layout_width="fill";
   id="mainfLay";
   {
-    LinearLayout,
+    FrameLayout,
     layoutTransition=LayoutTransition().enableTransitionType(LayoutTransition.CHANGING),
-    orientation="horizontal",
     layout_width="fill",id="fg";
     layout_height="fill",
   },

--- a/Hydrogen/app/src/main/assets_bin/layout/fragment.aly
+++ b/Hydrogen/app/src/main/assets_bin/layout/fragment.aly
@@ -6,56 +6,9 @@
   id="mainfLay";
   {
     LinearLayout,
-layoutTransition=LayoutTransition().enableTransitionType(LayoutTransition.CHANGING),
+    layoutTransition=LayoutTransition().enableTransitionType(LayoutTransition.CHANGING),
+    orientation="horizontal",
     layout_width="fill",id="fg";
     layout_height="fill",
-    {
-      FrameLayout,id="f1",
-      layout_width="fill",
-      layout_height="fill",
-      
-      {
-        LinearLayout,
-        gravity="center";
-        layout_width="fill",
-        layout_height="fill",
-        orientation="vertical";
-        {CircleImageView,layout_gravity="center";
-          imageDrawable=activity.getDrawable(R.drawable.welcome);
-          layout_width="64dp";
-          layout_height="64dp";
-        };
-        {TextView;
-          id="tttt";
-          layout_marginTop="6dp";
-          textColor=textc;layout_gravity="center";
-          text="Hydrogen，让每次点击都有意义";
-        };
-      },
-    },
-
-    {
-      FrameLayout;id="f2",
-      layout_width="fill",
-      layout_height="fill",
-      {
-        LinearLayout,
-        gravity="center";
-        layout_width="fill",
-        layout_height="fill",
-        orientation="vertical";
-        {CircleImageView,layout_gravity="center";
-          imageDrawable=activity.getDrawable(R.drawable.welcome);
-          layout_width="64dp";
-          layout_height="64dp";
-        };
-        {TextView;
-          id="tttt";
-          layout_marginTop="6dp";
-          textColor=textc;layout_gravity="center";
-          text="Hydrogen，让每次点击都有意义";
-        };
-      },
-    };
   },
 }

--- a/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
@@ -2,9 +2,20 @@ local MyLuaFileManager = {}
 MyLuaFileManager.__index = MyLuaFileManager
 
 local MaterialCardView = luajava.bindClass("com.google.android.material.card.MaterialCardView")
-local LinearLayout = luajava.bindClass("android.widget.LinearLayout")
 local FrameLayout = luajava.bindClass("android.widget.FrameLayout")
 local View = luajava.bindClass("android.view.View")
+local Gravity = luajava.bindClass("android.view.Gravity")
+
+local function resolveWidth(root)
+  local width = root.getWidth()
+  if not width or width <= 0 then
+    width = activity.getDecorView().getWidth()
+  end
+  if not width or width <= 0 then
+    width = activity.getResources().getDisplayMetrics().widthPixels
+  end
+  return width
+end
 
 local function newFrameLayout(activity)
   local frame = FrameLayout(activity)
@@ -15,7 +26,7 @@ end
 
 local function newCardContainer(activity)
   local card = MaterialCardView(activity)
-  card.setLayoutParams(LinearLayout.LayoutParams(0, -1, 1.0))
+  card.setLayoutParams(FrameLayout.LayoutParams(-1, -1))
   card.setCardElevation(0)
   card.setStrokeWidth(0)
   card.setRadius(0)
@@ -31,7 +42,6 @@ function MyLuaFileManager.new(rootContainer)
   self.containers = {}
 
   self.root.removeAllViews()
-  self.root.setOrientation(LinearLayout.HORIZONTAL)
 
   local firstCard = newCardContainer(activity)
   local secondCard = newCardContainer(activity)
@@ -46,16 +56,8 @@ function MyLuaFileManager.new(rootContainer)
   self.containers[1] = {card = firstCard, frame = firstFrame}
   self.containers[2] = {card = secondCard, frame = secondFrame}
 
-  self:setParallelMode(false, activity.getDecorView().width)
+  self:setParallelMode(false)
   return self
-end
-
-function MyLuaFileManager:getPrimaryContainer()
-  return self.containers[1].frame
-end
-
-function MyLuaFileManager:getSecondaryContainer()
-  return self.containers[2].frame
 end
 
 function MyLuaFileManager:getContainerPair()
@@ -64,25 +66,33 @@ end
 
 function MyLuaFileManager:setParallelMode(enabled, width)
   self.inSekai = enabled
+
   local firstCard = self.containers[1].card
   local secondCard = self.containers[2].card
+  local rootWidth = width or resolveWidth(self.root)
 
-  local firstParams = LinearLayout.LayoutParams(0, -1, 1.0)
-  local secondParams = LinearLayout.LayoutParams(0, -1, 1.0)
+  if enabled then
+    local half = math.floor(rootWidth * 0.5)
+    local gap = dp2px(8)
 
-  if enabled and width and width > 0 then
-    firstParams.width = math.floor(width * 0.5)
-    secondParams.width = 0
-    secondParams.setMarginStart(dp2px(8))
+    local firstParams = FrameLayout.LayoutParams(half - math.floor(gap / 2), -1)
+    firstParams.gravity = Gravity.START
+
+    local secondParams = FrameLayout.LayoutParams(half - math.floor(gap / 2), -1)
+    secondParams.gravity = Gravity.END
+
+    firstCard.setLayoutParams(firstParams)
+    secondCard.setLayoutParams(secondParams)
+    firstCard.setVisibility(View.VISIBLE)
+    secondCard.setVisibility(View.VISIBLE)
   else
-    local overlapWidth = width or activity.getDecorView().width
-    firstParams.width = overlapWidth
-    secondParams.width = overlapWidth
-    secondParams.setMarginStart(-1 * overlapWidth)
+    local overlayParams = FrameLayout.LayoutParams(-1, -1)
+    overlayParams.gravity = Gravity.START
+    firstCard.setLayoutParams(overlayParams)
+    secondCard.setLayoutParams(FrameLayout.LayoutParams(-1, -1))
+    firstCard.setVisibility(View.VISIBLE)
+    secondCard.setVisibility(View.VISIBLE)
   end
-
-  firstCard.setLayoutParams(firstParams)
-  secondCard.setLayoutParams(secondParams)
 end
 
 function MyLuaFileManager:selectTargetContainer(pageTag)

--- a/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
@@ -73,6 +73,19 @@ function MyLuaFileManager:getCardContainerByFrame(frame)
   return frame
 end
 
+function MyLuaFileManager:getCardContainerByView(view)
+  local current = view
+  while current do
+    for _, item in ipairs(self.containers) do
+      if current == item.card then
+        return item.card
+      end
+    end
+    current = current.getParent and current.getParent() or nil
+  end
+  return nil
+end
+
 function MyLuaFileManager:setParallelMode(enabled, width)
   self.inSekai = enabled
 

--- a/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
@@ -1,0 +1,123 @@
+local MyLuaFileManager = {}
+MyLuaFileManager.__index = MyLuaFileManager
+
+local MaterialCardView = luajava.bindClass("com.google.android.material.card.MaterialCardView")
+local LinearLayout = luajava.bindClass("android.widget.LinearLayout")
+local FrameLayout = luajava.bindClass("android.widget.FrameLayout")
+local View = luajava.bindClass("android.view.View")
+
+local function newFrameLayout(activity)
+  local frame = FrameLayout(activity)
+  frame.setLayoutParams(FrameLayout.LayoutParams(-1, -1))
+  frame.setId(View.generateViewId())
+  return frame
+end
+
+local function newCardContainer(activity)
+  local card = MaterialCardView(activity)
+  card.setLayoutParams(LinearLayout.LayoutParams(0, -1, 1.0))
+  card.setCardElevation(0)
+  card.setStrokeWidth(0)
+  card.setRadius(0)
+  card.setUseCompatPadding(false)
+  card.setPreventCornerOverlap(false)
+  return card
+end
+
+function MyLuaFileManager.new(rootContainer)
+  local self = setmetatable({}, MyLuaFileManager)
+  self.root = rootContainer
+  self.inSekai = false
+  self.containers = {}
+
+  self.root.removeAllViews()
+  self.root.setOrientation(LinearLayout.HORIZONTAL)
+
+  local firstCard = newCardContainer(activity)
+  local secondCard = newCardContainer(activity)
+  local firstFrame = newFrameLayout(activity)
+  local secondFrame = newFrameLayout(activity)
+
+  firstCard.addView(firstFrame)
+  secondCard.addView(secondFrame)
+  self.root.addView(firstCard)
+  self.root.addView(secondCard)
+
+  self.containers[1] = {card = firstCard, frame = firstFrame}
+  self.containers[2] = {card = secondCard, frame = secondFrame}
+
+  self:setParallelMode(false, activity.getDecorView().width)
+  return self
+end
+
+function MyLuaFileManager:getPrimaryContainer()
+  return self.containers[1].frame
+end
+
+function MyLuaFileManager:getSecondaryContainer()
+  return self.containers[2].frame
+end
+
+function MyLuaFileManager:getContainerPair()
+  return self.containers[1].frame, self.containers[2].frame
+end
+
+function MyLuaFileManager:setParallelMode(enabled, width)
+  self.inSekai = enabled
+  local firstCard = self.containers[1].card
+  local secondCard = self.containers[2].card
+
+  local firstParams = LinearLayout.LayoutParams(0, -1, 1.0)
+  local secondParams = LinearLayout.LayoutParams(0, -1, 1.0)
+
+  if enabled and width and width > 0 then
+    firstParams.width = math.floor(width * 0.5)
+    secondParams.width = 0
+    secondParams.setMarginStart(dp2px(8))
+  else
+    local overlapWidth = width or activity.getDecorView().width
+    firstParams.width = overlapWidth
+    secondParams.width = overlapWidth
+    secondParams.setMarginStart(-1 * overlapWidth)
+  end
+
+  firstCard.setLayoutParams(firstParams)
+  secondCard.setLayoutParams(secondParams)
+end
+
+function MyLuaFileManager:selectTargetContainer(pageTag)
+  local f1, f2 = self:getContainerPair()
+  local ff = f1
+
+  if tonumber(f1.getTag(R.id.tag_last_time)) > tonumber(f2.getTag(R.id.tag_last_time)) then
+    ff = f2
+  else
+    ff = f1
+  end
+
+  if f2.tag == pageTag then
+    ff = f2
+  end
+
+  if not self.inSekai then
+    ff = f1
+  end
+
+  return ff
+end
+
+function MyLuaFileManager:markContainer(container, pageTag)
+  local nt = tonumber(os.time())
+  container.tag = pageTag
+  container.setTag(R.id.tag_last_time, nt)
+end
+
+function MyLuaFileManager:initDefaultTags()
+  local f1, f2 = self:getContainerPair()
+  f1.setTag("home")
+  f1.setTag(R.id.tag_last_time, tonumber(os.time()))
+  f2.setTag("empty")
+  f2.setTag(R.id.tag_last_time, tonumber(os.time()) - 114514)
+end
+
+return MyLuaFileManager

--- a/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
@@ -64,6 +64,15 @@ function MyLuaFileManager:getContainerPair()
   return self.containers[1].frame, self.containers[2].frame
 end
 
+function MyLuaFileManager:getCardContainerByFrame(frame)
+  for _, item in ipairs(self.containers) do
+    if item.frame == frame then
+      return item.card
+    end
+  end
+  return frame
+end
+
 function MyLuaFileManager:setParallelMode(enabled, width)
   self.inSekai = enabled
 

--- a/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/MyLuaFileManager.lua
@@ -85,13 +85,15 @@ function MyLuaFileManager:setParallelMode(enabled, width)
     secondCard.setLayoutParams(secondParams)
     firstCard.setVisibility(View.VISIBLE)
     secondCard.setVisibility(View.VISIBLE)
+    firstCard.bringToFront()
   else
     local overlayParams = FrameLayout.LayoutParams(-1, -1)
     overlayParams.gravity = Gravity.START
     firstCard.setLayoutParams(overlayParams)
     secondCard.setLayoutParams(FrameLayout.LayoutParams(-1, -1))
     firstCard.setVisibility(View.VISIBLE)
-    secondCard.setVisibility(View.VISIBLE)
+    secondCard.setVisibility(View.GONE)
+    firstCard.bringToFront()
   end
 end
 

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -154,6 +154,10 @@ function 设置视图(t)
 
   if thisFragment
     thisFragment.container.setBackgroundColor(0x99000000)
+    local thisCardContainer = thisFragment.container
+    if myLuaFileManager then
+      thisCardContainer = myLuaFileManager:getCardContainerByFrame(thisFragment.container)
+    end
     local lay = loadlayout(t)
     if lay.id == "mainLay" then
       lay.setBackgroundColor(0)
@@ -163,11 +167,11 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=buildMixedTransition(false,thisFragment.container,thisFragment.container,nOView,OldWindowShape)
+      local backward=buildMixedTransition(false,thisCardContainer,thisCardContainer,nOView,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
-      local backward = buildMixedTransition(false,thisFragment.container,nil,thisFragment.container)
+      local backward = buildMixedTransition(false,thisCardContainer,nil,thisCardContainer)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
     end
@@ -233,8 +237,12 @@ function newActivity(f,b,c)
     end
     fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build()} )
     fragment.postponeEnterTransition()
-    local forward=buildMixedTransition(true,ff,nTView,ff)
-    local backward=buildMixedTransition(false,ff,ff,nTView,WindowShape.build())
+    local ffCardContainer = ff
+    if myLuaFileManager then
+      ffCardContainer = myLuaFileManager:getCardContainerByFrame(ff)
+    end
+    local forward=buildMixedTransition(true,ffCardContainer,nTView,ffCardContainer)
+    local backward=buildMixedTransition(false,ffCardContainer,ffCardContainer,nTView,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -119,16 +119,13 @@ function MyLuaFileFragment(a,b,c)
   },a,b,c)
 end
 
-local function buildMixedTransition(isForward, axisTargetView, axisFallbackView, startView, endView, shapeModel)
+local function buildMixedTransition(isForward, axisTargetView, startView, endView, shapeModel)
   local set = TransitionSet()
   set.setOrdering(TransitionSet.ORDERING_TOGETHER)
 
   local axis = MaterialSharedAxis(MaterialSharedAxis.Z, isForward)
   if axisTargetView then
     axis.addTarget(axisTargetView)
-  end
-  if axisFallbackView and axisFallbackView ~= axisTargetView then
-    axis.addTarget(axisFallbackView)
   end
 
   local container = MaterialContainerTransform(activity, isForward)
@@ -174,11 +171,11 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=buildMixedTransition(false,lastCardContainer,thisCardContainer,thisCardContainer,nOView,OldWindowShape)
+      local backward=buildMixedTransition(false,lastCardContainer,thisCardContainer,nOView,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
-      local backward = buildMixedTransition(false,thisCardContainer,thisCardContainer,nil,thisCardContainer)
+      local backward = buildMixedTransition(false,thisCardContainer,nil,thisCardContainer)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
     end
@@ -255,8 +252,8 @@ function newActivity(f,b,c)
     end
     fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build(),LastContainer=lastCardContainer} )
     fragment.postponeEnterTransition()
-    local forward=buildMixedTransition(true,lastCardContainer,ffCardContainer,nTView,ffCardContainer,nil)
-    local backward=buildMixedTransition(false,lastCardContainer,ffCardContainer,ffCardContainer,nTView,WindowShape.build())
+    local forward=buildMixedTransition(true,lastCardContainer,nTView,ffCardContainer,nil)
+    local backward=buildMixedTransition(false,lastCardContainer,ffCardContainer,nTView,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -53,7 +53,7 @@ layout_dir="layout/item_layout/"
 
 import "android.animation.ObjectAnimator"
 import "android.view.animation.*"
-local TransitionSet = luajava_bindClass "android.transition.TransitionSet"
+local TransitionSet = luajava_bindClass "androidx.transition.TransitionSet"
 
 function addAutoHideListener(recs,views)
   local appbar

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -119,13 +119,13 @@ function MyLuaFileFragment(a,b,c)
   },a,b,c)
 end
 
-local function buildMixedTransition(isForward, targetView, startView, endView, shapeModel)
+local function buildMixedTransition(isForward, axisTargetView, startView, endView, shapeModel)
   local set = TransitionSet()
   set.setOrdering(TransitionSet.ORDERING_TOGETHER)
 
   local axis = MaterialSharedAxis(MaterialSharedAxis.Z, isForward)
-  if targetView then
-    axis.addTarget(targetView)
+  if axisTargetView then
+    axis.addTarget(axisTargetView)
   end
 
   local container = MaterialContainerTransform(activity, isForward)
@@ -171,7 +171,7 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=buildMixedTransition(false,thisCardContainer,thisCardContainer,lastCardContainer,OldWindowShape)
+      local backward=buildMixedTransition(false,lastCardContainer,thisCardContainer,nOView,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
@@ -252,8 +252,8 @@ function newActivity(f,b,c)
     end
     fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build(),LastContainer=lastCardContainer} )
     fragment.postponeEnterTransition()
-    local forward=buildMixedTransition(true,ffCardContainer,lastCardContainer,ffCardContainer)
-    local backward=buildMixedTransition(false,ffCardContainer,ffCardContainer,lastCardContainer,WindowShape.build())
+    local forward=buildMixedTransition(true,lastCardContainer,nTView,ffCardContainer)
+    local backward=buildMixedTransition(false,lastCardContainer,ffCardContainer,nTView,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -53,6 +53,7 @@ layout_dir="layout/item_layout/"
 
 import "android.animation.ObjectAnimator"
 import "android.view.animation.*"
+local TransitionSet = luajava_bindClass "android.transition.TransitionSet"
 
 function addAutoHideListener(recs,views)
   local appbar
@@ -118,6 +119,34 @@ function MyLuaFileFragment(a,b,c)
   },a,b,c)
 end
 
+local function buildMixedTransition(isForward, targetView, startView, endView, shapeModel)
+  local set = TransitionSet()
+  set.setOrdering(TransitionSet.ORDERING_TOGETHER)
+
+  local axis = MaterialSharedAxis(MaterialSharedAxis.Z, isForward)
+  if targetView then
+    axis.addTarget(targetView)
+  end
+
+  local container = MaterialContainerTransform(activity, isForward)
+  if startView then
+    container.setStartView(startView)
+  end
+  if endView then
+    container.setEndView(endView)
+    container.addTarget(endView)
+  end
+  if shapeModel then
+    container.setStartShapeAppearanceModel(shapeModel)
+  end
+  container.setPathMotion(MaterialArcMotion())
+  container.setScrimColor(0x99000000)
+
+  set.addTransition(container)
+  set.addTransition(axis)
+  return set
+end
+
 function 设置视图(t)
   if tostring(this.getSharedData("预见性返回手势"))=="false"
     this.getSupportFragmentManager().enablePredictiveBack(false)
@@ -134,20 +163,11 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=MaterialContainerTransform(activity,false)
-      .setStartView(thisFragment.container)
-      .setEndView(nOView)
-      .setPathMotion(MaterialArcMotion())
-      .setScrimColor(0x99000000)
-      .addTarget(nOView)
-      .setStartShapeAppearanceModel(OldWindowShape)
+      local backward=buildMixedTransition(false,thisFragment.container,thisFragment.container,nOView,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
-      local backward = MaterialSharedAxis(MaterialSharedAxis.Z, false)
-      .addTarget(thisFragment.container)
-      .addTarget(thisFragment.container)
-      --.addTarget(ff)
+      local backward = buildMixedTransition(false,thisFragment.container,nil,thisFragment.container)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
     end
@@ -213,11 +233,8 @@ function newActivity(f,b,c)
     end
     fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build()} )
     fragment.postponeEnterTransition()
-    local forward=MaterialContainerTransform(activity,true)
-    .setStartView(nTView)
-    .setPathMotion(MaterialArcMotion())
-    .setEndShapeAppearanceModel(WindowShape.build())
-    .setScrimColor(0x99000000)
+    local forward=buildMixedTransition(true,ff,nTView,ff)
+    local backward=buildMixedTransition(false,ff,ff,nTView,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -155,8 +155,12 @@ function 设置视图(t)
   if thisFragment
     thisFragment.container.setBackgroundColor(0x99000000)
     local thisCardContainer = thisFragment.container
+    local lastCardContainer = LastContainer
     if myLuaFileManager then
       thisCardContainer = myLuaFileManager:getCardContainerByFrame(thisFragment.container)
+      if not lastCardContainer then
+        lastCardContainer = thisCardContainer
+      end
     end
     local lay = loadlayout(t)
     if lay.id == "mainLay" then
@@ -167,7 +171,7 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=buildMixedTransition(false,thisCardContainer,thisCardContainer,nOView,OldWindowShape)
+      local backward=buildMixedTransition(false,thisCardContainer,thisCardContainer,lastCardContainer,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
@@ -235,14 +239,21 @@ function newActivity(f,b,c)
         WindowShape.setBottomLeftCornerSize(0)
       end
     end
-    fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build()} )
-    fragment.postponeEnterTransition()
+    local lastCardContainer = nil
+    if myLuaFileManager then
+      lastCardContainer = myLuaFileManager:getCardContainerByView(nTView)
+    end
     local ffCardContainer = ff
     if myLuaFileManager then
       ffCardContainer = myLuaFileManager:getCardContainerByFrame(ff)
     end
-    local forward=buildMixedTransition(true,ffCardContainer,nTView,ffCardContainer)
-    local backward=buildMixedTransition(false,ffCardContainer,ffCardContainer,nTView,WindowShape.build())
+    if not lastCardContainer then
+      lastCardContainer = ffCardContainer
+    end
+    fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build(),LastContainer=lastCardContainer} )
+    fragment.postponeEnterTransition()
+    local forward=buildMixedTransition(true,ffCardContainer,lastCardContainer,ffCardContainer)
+    local backward=buildMixedTransition(false,ffCardContainer,ffCardContainer,lastCardContainer,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);
@@ -253,10 +264,14 @@ function newActivity(f,b,c)
     t.addSharedElement(nTView,"t")
     fragment.setSharedElementEnterTransition(forward).setSharedElementReturnTransition(backward).setEnterTransition(forward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
     t.add(ff.id,fragment)
-   else
+  else
     backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);
     forward = MaterialSharedAxis(MaterialSharedAxis.Z, true);
-    local fragment = MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,})
+    local lastCardContainer = ff
+    if myLuaFileManager then
+      lastCardContainer = myLuaFileManager:getCardContainerByFrame(ff)
+    end
+    local fragment = MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,LastContainer=lastCardContainer})
     fragment.postponeEnterTransition()
     t.add(ff.id,fragment.setEnterTransition(forward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward))
 

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -105,7 +105,9 @@ function MyLuaFileFragment(a,b,c)
       this.getLuaState().setGlobal("currentFragment")
 
       local ff = f2
-      if tonumber(f1.getTag(R.id.tag_last_time))>tonumber(f2.getTag(R.id.tag_last_time))
+      if myLuaFileManager then
+        ff = myLuaFileManager:selectTargetContainer("empty")
+      elseif tonumber(f1.getTag(R.id.tag_last_time))>tonumber(f2.getTag(R.id.tag_last_time))
         ff=f2
        else
         ff=f1
@@ -169,17 +171,22 @@ function newActivity(f,b,c)
   --t.remove(activity.getSupportFragmentManager().findFragmentByTag("answer"))
   --t.add(thisF.getId(),MyLuaFileFragment(srcLuaDir..f..".lua",b,{fn=fn,fg=fg,inSekai=inSekai,onBackCancelled=onBackCancelled,onBackStarted=onBackStarted,onBackInvoked=onBackInvoked,onBackProgressed=onBackProgressed}))
   --t.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
-  if tonumber(f1.getTag(R.id.tag_last_time))>tonumber(f2.getTag(R.id.tag_last_time))
-    ff=f2
+  if myLuaFileManager then
+    ff = myLuaFileManager:selectTargetContainer(f)
+    myLuaFileManager:markContainer(ff, f)
    else
-    ff=f1
+    if tonumber(f1.getTag(R.id.tag_last_time))>tonumber(f2.getTag(R.id.tag_last_time))
+      ff=f2
+     else
+      ff=f1
+    end
+    if f2.tag==f
+      ff=f2
+    end
+    if !inSekai then ff = f1 end
+    ff.tag=f
+    ff.setTag(R.id.tag_last_time,nt)
   end
-  if f2.tag==f
-    ff=f2
-  end
-  if !inSekai then ff = f1 end
-  ff.tag=f
-  ff.setTag(R.id.tag_last_time,nt)
   if nTView then
     --https://developer.android.google.cn/reference/android/view/RoundedCorner#POSITION_BOTTOM_LEFT
 

--- a/Hydrogen/app/src/main/assets_bin/mods/muk.lua
+++ b/Hydrogen/app/src/main/assets_bin/mods/muk.lua
@@ -119,13 +119,16 @@ function MyLuaFileFragment(a,b,c)
   },a,b,c)
 end
 
-local function buildMixedTransition(isForward, axisTargetView, startView, endView, shapeModel)
+local function buildMixedTransition(isForward, axisTargetView, axisFallbackView, startView, endView, shapeModel)
   local set = TransitionSet()
   set.setOrdering(TransitionSet.ORDERING_TOGETHER)
 
   local axis = MaterialSharedAxis(MaterialSharedAxis.Z, isForward)
   if axisTargetView then
     axis.addTarget(axisTargetView)
+  end
+  if axisFallbackView and axisFallbackView ~= axisTargetView then
+    axis.addTarget(axisFallbackView)
   end
 
   local container = MaterialContainerTransform(activity, isForward)
@@ -171,11 +174,11 @@ function 设置视图(t)
     end
     thisFragment.setContainerView(lay)
     if nOView~=nil
-      local backward=buildMixedTransition(false,lastCardContainer,thisCardContainer,nOView,OldWindowShape)
+      local backward=buildMixedTransition(false,lastCardContainer,thisCardContainer,thisCardContainer,nOView,OldWindowShape)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
      else
-      local backward = buildMixedTransition(false,thisCardContainer,nil,thisCardContainer)
+      local backward = buildMixedTransition(false,thisCardContainer,thisCardContainer,nil,thisCardContainer)
       thisFragment.setSharedElementReturnTransition(backward).setReenterTransition(backward).setExitTransition(backward).setReturnTransition(backward)
       thisFragment.startPostponedEnterTransition()
     end
@@ -252,8 +255,8 @@ function newActivity(f,b,c)
     end
     fragment=MyLuaFileFragment(srcLuaDir..f..".lua",b,{f1=f1,f2=f2,inSekai=inSekai,ff=ff,nOView=nTView,OldWindowShape=WindowShape.build(),LastContainer=lastCardContainer} )
     fragment.postponeEnterTransition()
-    local forward=buildMixedTransition(true,lastCardContainer,nTView,ffCardContainer)
-    local backward=buildMixedTransition(false,lastCardContainer,ffCardContainer,nTView,WindowShape.build())
+    local forward=buildMixedTransition(true,lastCardContainer,ffCardContainer,nTView,ffCardContainer,nil)
+    local backward=buildMixedTransition(false,lastCardContainer,ffCardContainer,ffCardContainer,nTView,WindowShape.build())
     --.setAllContainerColors(转0x(backgroundc))
     --.setFadeMode(3)
     --backward = MaterialSharedAxis(MaterialSharedAxis.Z, false);


### PR DESCRIPTION
### Motivation
- Centralize creation and management of the two fragment host containers so the layout and container-selection logic are maintained in one place via a file manager.
- Allow each container to be wrapped in a `MaterialCardView` so the two containers can be displayed side-by-side (parallel) or overlapping on the `fg` host depending on screen width (`inSekai`).
- Simplify static layout and fragment lifecycle code by delegating container sizing/selection/tagging to a small API instead of manual view manipulation across scripts.

### Description
- Add `mods/MyLuaFileManager.lua` which programmatically creates two `MaterialCardView` wrappers containing `FrameLayout` hosts and exposes `new`, `getContainerPair`, `setParallelMode`, `selectTargetContainer`, `markContainer`, and `initDefaultTags` APIs.
- Update `app/src/main/assets_bin/home.lua` to `require "mods.MyLuaFileManager"`, instantiate the manager with `MyLuaFileManager.new(fg)`, obtain `f1,f2` via `getContainerPair()`, call `setParallelMode` on layout changes, and initialize tags with `initDefaultTags()`.
- Simplify `app/src/main/assets_bin/layout/fragment.aly` so `fg` is now a dedicated horizontal host for the manager to populate instead of containing static `f1`/`f2` frames.
- Adjust `app/src/main/assets_bin/mods/muk.lua` to prefer `myLuaFileManager` for selecting and marking the target container in `MyLuaFileFragment.onDestroy` and `newActivity`, while keeping the original logic as a fallback when the manager is not present.

### Testing
- Ran `git diff --check` which completed without issues.
- Verified repository changes were committed successfully (commit created during the rollout).
- No automated runtime tests were run in this environment; changes are limited to Lua layout/coordination code and include fallbacks to existing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0c3800aec832ea2c5c1da1c553e61)